### PR TITLE
Browser Build: ConfigOverride.xcconfig (#836)

### DIFF
--- a/.github/workflows/add_identifiers.yml
+++ b/.github/workflows/add_identifiers.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Fastlane Provision
         run: bundle exec fastlane identifiers
         env:
+          APP_IDENTIFIER: ${{ secrets.APP_IDENTIFIER }}
           TEAMID: ${{ secrets.TEAMID }}
           GH_PAT: ${{ secrets.GH_PAT }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}

--- a/.github/workflows/build_iAPS.yml
+++ b/.github/workflows/build_iAPS.yml
@@ -204,6 +204,7 @@ jobs:
       - name: Fastlane Build & Archive
         run: bundle exec fastlane build_iAPS        
         env:
+          APP_IDENTIFIER: ${{ secrets.APP_IDENTIFIER }}
           TEAMID: ${{ secrets.TEAMID }}
           GH_PAT: ${{ secrets.GH_PAT }}
           FASTLANE_KEY_ID: ${{ secrets.FASTLANE_KEY_ID }}
@@ -215,6 +216,7 @@ jobs:
       - name: Fastlane upload to TestFlight
         run: bundle exec fastlane release
         env:
+          APP_IDENTIFIER: ${{ secrets.APP_IDENTIFIER }}
           TEAMID: ${{ secrets.TEAMID }}
           GH_PAT: ${{ secrets.GH_PAT }}
           FASTLANE_KEY_ID: ${{ secrets.FASTLANE_KEY_ID }}

--- a/.github/workflows/create_certs.yml
+++ b/.github/workflows/create_certs.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Create Certificates
         run: bundle exec fastlane certs
         env:
+          APP_IDENTIFIER: ${{ secrets.APP_IDENTIFIER }}
           TEAMID: ${{ secrets.TEAMID }}
           GH_PAT: ${{ secrets.GH_PAT }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}

--- a/.github/workflows/validate_secrets.yml
+++ b/.github/workflows/validate_secrets.yml
@@ -121,6 +121,7 @@ jobs:
       FASTLANE_KEY: ${{ secrets.FASTLANE_KEY }}
       MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
       TEAMID: ${{ secrets.TEAMID }}
+      APP_IDENTIFIER: ${{ secrets.APP_IDENTIFIER }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,13 +22,15 @@ FASTLANE_KEY = ENV["FASTLANE_KEY"]
 DEVICE_NAME = ENV["DEVICE_NAME"]
 DEVICE_ID = ENV["DEVICE_ID"]
 ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "120"
-APP_IDENTIFIER = "ru.artpancreas.#{TEAMID}.FreeAPS"
+APP_IDENTIFIER = ENV["APP_IDENTIFIER"] || "ru.artpancreas.#{TEAMID}.FreeAPS"
 
 platform :ios do
   desc "Build iAPS"
   lane :build_iAPS do
     setup_ci if ENV['CI']
-    
+
+    sh "scripts/CreateConfigOverride.sh", "#{APP_IDENTIFIER}"
+ 
     update_project_team(
       path: "#{GITHUB_WORKSPACE}/FreeAPS.xcodeproj",
       teamid: "#{TEAMID}"

--- a/fastlane/scripts/CreateConfigOverride.sh
+++ b/fastlane/scripts/CreateConfigOverride.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "BUNDLE_IDENTIFIER = $1" > ../ConfigOverride.xcconfig

--- a/fastlane/testflight.md
+++ b/fastlane/testflight.md
@@ -52,6 +52,7 @@ If you have previously built Loop or another app using the "browser build" metho
     * `FASTLANE_KEY`
     * `GH_PAT`
     * `MATCH_PASSWORD` - just make up a password for this
+    * 'APP_IDENTIFIER' - optional, if you want to use a different BUNDLE_IDENTIFIER then `ru.artpancreas.$(DEVELOPMENT_TEAM).FreeAPS`.
 
 ## Validate repository secrets
 


### PR DESCRIPTION
* Add code to allow custom APP_IDENTIFIER

* add APP_IDENTIFIER to list of environment avriables

* make sure we call the right script

* remove before_all as its in wrong place anyway

* add a pwd

* try and fix scripts/CreateConfigOverride.sh

* add denbugging

* add one more

* direct sh call

* Clean out debug command

* add a comment abotu APP_IDENTIFIER to testflight.md

* change comment a bit